### PR TITLE
CHORE - Change the beneficiary amounts registry out of the registry

### DIFF
--- a/contracts/BandoFulfillmentManagerV1.sol
+++ b/contracts/BandoFulfillmentManagerV1.sol
@@ -10,32 +10,30 @@ import './BandoERC20FulfillableV1.sol';
 import './BandoFulfillableV1.sol';
 import './FulfillmentTypes.sol';
 
-/**
- * @title BandoFulfillmentManager
- * 
- * This contract manages services and fulfillables for the Bando protocol.
- * It inherits from OwnableUpgradeable and UUPSUpgradeable contracts.
- * 
- * OwnableUpgradeable provides basic access control functionality, 
- * where only the contract owner can perform certain actions.
- * 
- * UUPSUpgradeable enables the contract to be upgraded without 
- * losing its state, allowing for seamless upgrades of the 
- * contract's implementation logic.
- * 
- * The purpose pf this contract is to interact with the FulfillableRegistry
- * and the BandoFulfillable contracts to perform the following actions:
- * 
- * - Set up a service escrow address and validator address.
- * - Register a fulfillment result for a service.
- * - Withdraw a refund from a service.
- * - Withdraw funds for a beneficiary in a releasable pool.
- * 
- * The owner of the contract is the operator of the fulfillment protocol.
- * But the fulfillers are the only ones that can register a fulfillment result 
- * and withdraw a refund.
- * 
- */
+
+/// @title BandoFulfillmentManagerV1
+/// 
+/// This contract manages services and fulfillables for the Bando protocol.
+/// It inherits from OwnableUpgradeable and UUPSUpgradeable contracts.
+/// 
+/// OwnableUpgradeable provides basic access control functionality, 
+/// where only the contract owner can perform certain actions.
+/// 
+/// UUPSUpgradeable enables the contract to be upgraded without 
+/// losing its state, allowing for seamless upgrades of the 
+/// contract's implementation logic.
+/// 
+/// The purpose of this contract is to interact with the FulfillableRegistry
+/// and the BandoFulfillable contracts to perform the following actions:
+/// 
+/// - Set up a service escrow address and validator address.
+/// - Register a fulfillment result for a service.
+/// - Withdraw a refund from a service.
+/// - Withdraw funds for a beneficiary in a releasable pool.
+/// 
+/// The owner of the contract is the operator of the fulfillment protocol.
+/// But the fulfillers are the only ones that can register a fulfillment result 
+/// and withdraw a refund.
 contract BandoFulfillmentManagerV1 is OwnableUpgradeable, UUPSUpgradeable, ReentrancyGuardUpgradeable {
 
     address public _serviceRegistry;
@@ -108,7 +106,6 @@ contract BandoFulfillmentManagerV1 is OwnableUpgradeable, UUPSUpgradeable, Reent
             serviceId: serviceID,
             fulfiller: fulfiller,
             feeAmount: feeAmount,
-            releaseablePool: 0,
             beneficiary: beneficiary
         });
         IFulfillableRegistry(_serviceRegistry).addService(serviceID, service);

--- a/contracts/periphery/registry/FulfillableRegistry.sol
+++ b/contracts/periphery/registry/FulfillableRegistry.sol
@@ -94,17 +94,6 @@ contract FulfillableRegistry is IFulfillableRegistry, UUPSUpgradeable, OwnableUp
     }
 
     /**
-     * @notice updateServiceReleaseablePool
-     * @dev Updates the releaseable pool of a service.
-     * @param serviceId the service identifier
-     * @param newReleaseablePool the new releaseable pool amount
-     */
-    function updateServiceReleaseablePool(uint256 serviceId, uint256 newReleaseablePool) external {
-        require(_serviceRegistry[serviceId].fulfiller != address(0), 'FulfillableRegistry: Service does not exist');
-        _serviceRegistry[serviceId].releaseablePool = newReleaseablePool;
-    }
-
-    /**
      * @notice updateServiceFulfiller
      * @dev Updates the fulfiller of a service.
      * @param serviceId the service identifier

--- a/contracts/periphery/registry/IFulfillableRegistry.sol
+++ b/contracts/periphery/registry/IFulfillableRegistry.sol
@@ -19,7 +19,6 @@ struct Service {
     uint256 serviceId;
     address payable beneficiary;
     uint256 feeAmount;
-    uint256 releaseablePool;
     address fulfiller;
 }
 
@@ -75,14 +74,6 @@ interface IFulfillableRegistry {
      * @param newFeeAmount the new fee amount
      */
     function updateServiceFeeAmount(uint256 serviceId, uint256 newFeeAmount) external;
-
-    /**
-     * @notice updateServiceReleaseablePool
-     * @dev Updates the releaseable pool of a service.
-     * @param serviceId the service identifier
-     * @param newReleaseablePool the new releaseable pool amount
-     */
-    function updateServiceReleaseablePool(uint256 serviceId, uint256 newReleaseablePool) external;
 
     /**
      * @notice updateServiceFulfiller

--- a/test/utils/registryUtils.js
+++ b/test/utils/registryUtils.js
@@ -6,7 +6,6 @@ const DUMMY_SERVICE = {
   serviceId: 1,
   beneficiary: DUMMY_ADDRESS,
   feeAmount: 100,
-  releaseablePool: 1000,
   fulfiller: DUMMY_ADDRESS
 };
 
@@ -14,7 +13,6 @@ const DUMMY_SERVICE_2 = {
   serviceId: 2,
   beneficiary: DUMMY_ADDRESS,
   feeAmount: 200,
-  releaseablePool: 2000,
   fulfiller: DUMMY_ADDRESS
 };
 
@@ -22,7 +20,6 @@ const DUMMY_SERVICE_3 = {
   serviceId: 3,
   beneficiary: DUMMY_ADDRESS,
   feeAmount: 300,
-  releaseablePool: 3000,
   fulfiller: DUMMY_ADDRESS
 };
 


### PR DESCRIPTION
This PR moves the `releaseablePool` (amount to deposit to a beneficiary) from the registry contract into the core fulfillable escrow contract. This reduces complexity and keeps escrow amount encapsulated in the core contract, mitigating cross-contract risks.